### PR TITLE
Some overflows checks, for sysctl for example sysctl kern.maxfiles=99999...

### DIFF
--- a/bin/ls/ls.c
+++ b/bin/ls/ls.c
@@ -162,6 +162,7 @@ main(int argc, char *argv[])
 	char tcapbuf[512];	/* capability buffer */
 	char *bp = tcapbuf;
 #endif
+	const char *errstr = NULL;
 
 	(void)setlocale(LC_ALL, "");
 
@@ -169,7 +170,7 @@ main(int argc, char *argv[])
 	if (isatty(STDOUT_FILENO)) {
 		termwidth = 80;
 		if ((p = getenv("COLUMNS")) != NULL && *p != '\0')
-			termwidth = atoi(p);
+			termwidth = strtonum(p, 0, INT_MAX, &errstr);
 		else if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &win) != -1 &&
 		    win.ws_col > 0)
 			termwidth = win.ws_col;
@@ -179,9 +180,11 @@ main(int argc, char *argv[])
 		/* retrieve environment variable, in case of explicit -C */
 		p = getenv("COLUMNS");
 		if (p)
-			termwidth = atoi(p);
+			termwidth = strtonum(p, 0, INT_MAX, &errstr);
 	}
 
+	if (errstr)
+		termwidth = 80;
 	fts_options = FTS_PHYSICAL;
 	if (getenv("LS_SAMESORT"))
 		f_samesort = 1;

--- a/bin/pax/options.c
+++ b/bin/pax/options.c
@@ -189,6 +189,7 @@ pax_options(int argc, char **argv)
 	unsigned int flg = 0;
 	unsigned int bflg = 0;
 	char *pt;
+	const char *errstr = NULL;
 	FSUB tmp;
 
 	/*
@@ -417,9 +418,12 @@ pax_options(int argc, char **argv)
 			flg |= CEF;
 			if (strcmp(NONE, optarg) == 0)
 				maxflt = -1;
-			else if ((maxflt = atoi(optarg)) < 0) {
-				paxwarn(1, "Error count value must be positive");
-				pax_usage();
+			else {
+				maxflt = strtonum(optarg, 0, INT_MAX, &errstr);
+				if (errstr) { 
+					paxwarn(1, "Error count value %s", errstr);
+					pax_usage();
+				}
 			}
 			break;
 		case 'G':
@@ -1016,6 +1020,7 @@ cpio_options(int argc, char **argv)
 	int c;
 	size_t i;
 	char *str;
+	const char *errstr = NULL;
 	FSUB tmp;
 	FILE *fp;
 
@@ -1143,7 +1148,11 @@ cpio_options(int argc, char **argv)
 				/*
 				 * set block size in bytes
 				 */
-				wrblksz = atoi(optarg);
+				wrblksz = strtonum(optarg, 0, INT_MAX, &errstr);
+				if (errstr) {
+					paxwarn(1, "Invalid block size %s", errstr);
+					cpio_usage();
+				}
 				break;
 			case 'E':
 				/*

--- a/contrib/nvi/cl/cl_term.c
+++ b/contrib/nvi/cl/cl_term.c
@@ -360,6 +360,7 @@ cl_ssize(SCR *sp, int sigwinch, size_t *rowp, size_t *colp, int *changedp)
 	size_t col, row;
 	int rval;
 	char *p;
+	char *rowptr = NULL, *colptr = NULL;
 
 	/* Assume it's changed. */
 	if (changedp != NULL)
@@ -451,10 +452,16 @@ noterm:	if (row == 0)
 	 * deleting the LINES and COLUMNS environment variables from their
 	 * dot-files.
 	 */
-	if ((p = getenv("LINES")) != NULL)
-		row = strtol(p, NULL, 10);
-	if ((p = getenv("COLUMNS")) != NULL)
-		col = strtol(p, NULL, 10);
+	if ((p = getenv("LINES")) != NULL) {
+		row = strtol(p, &rowptr, 10);
+		if (errno == ERANGE || *rowptr != '\0')
+			row = 24;
+	}
+	if ((p = getenv("COLUMNS")) != NULL) {
+		col = strtol(p, &colptr, 10);
+		if (errno == ERANGE || *colptr != '\0')
+			col = 80;
+	}
 
 	if (rowp != NULL)
 		*rowp = row;

--- a/sbin/camcontrol/camcontrol.c
+++ b/sbin/camcontrol/camcontrol.c
@@ -5379,6 +5379,7 @@ scsiformat(struct cam_device *device, int argc, char **argv,
 	 && (timeout == 0)) {
 		char str[1024];
 		int new_timeout = 0;
+		const char *errstr = NULL;
 
 		fprintf(stdout, "Enter new timeout in seconds or press\n"
 			"return to keep the current timeout [%d] ",
@@ -5386,7 +5387,11 @@ scsiformat(struct cam_device *device, int argc, char **argv,
 
 		if (fgets(str, sizeof(str), stdin) != NULL) {
 			if (str[0] != '\0')
-				new_timeout = atoi(str);
+				new_timeout = strtonum(str, 0, INT_MAX, &errstr);
+				if (errstr) {
+					fprintf(stderr, "Invalid new timeout %s\n", errstr);
+					goto scsiformat_bailout;
+				}
 		}
 
 		if (new_timeout != 0) {
@@ -5787,6 +5792,8 @@ scsisanitize(struct cam_device *device, int argc, char **argv,
 	 && (timeout == 0)) {
 		char str[1024];
 		int new_timeout = 0;
+		const char *errstr = NULL;
+		
 
 		fprintf(stdout, "Enter new timeout in seconds or press\n"
 			"return to keep the current timeout [%d] ",
@@ -5794,7 +5801,11 @@ scsisanitize(struct cam_device *device, int argc, char **argv,
 
 		if (fgets(str, sizeof(str), stdin) != NULL) {
 			if (str[0] != '\0')
-				new_timeout = atoi(str);
+				new_timeout = strtonum(str, 0, INT_MAX, &errstr);
+				if (errstr) {
+					fprintf(stderr, "Invalid new timeout %s\n", errstr);
+					goto scsisanitize_bailout;
+				}
 		}
 
 		if (new_timeout != 0) {

--- a/sbin/comcontrol/comcontrol.c
+++ b/sbin/comcontrol/comcontrol.c
@@ -57,6 +57,7 @@ main(int argc, char *argv[])
 	int     res = 0;
 	int     print_dtrwait = 1, print_drainwait = 1;
 	int     dtrwait = -1, drainwait = -1;
+	char	*dtrwaitptr = NULL, *drainwaitptr = NULL;
 
 	if (argc < 2)
 		usage();
@@ -97,14 +98,18 @@ main(int argc, char *argv[])
 					usage();
 				if (argv[3] == NULL || !isdigit(argv[3][0]))
 					usage();
-				dtrwait = atoi(argv[3]);
+				dtrwait = strtol(argv[3], &dtrwaitptr, 10);
+				if (errno == ERANGE || *dtrwaitptr != '\0')
+					usage();
 				argv += 2;
 			} else if (!strcmp(argv[2],"drainwait")) {
 				if (drainwait >= 0)
 					usage();
 				if (argv[3] == NULL || !isdigit(argv[3][0]))
 					usage();
-				drainwait = atoi(argv[3]);
+				drainwait = strtol(argv[3], &drainwaitptr, 10);
+				if (errno == ERANGE || *drainwaitptr != '\0')
+					usage();
 				argv += 2;
 			} else
 				usage();

--- a/sbin/fsdb/fsdbutil.c
+++ b/sbin/fsdb/fsdbutil.c
@@ -209,13 +209,14 @@ charsperline(void)
 	int columns;
 	char *cp;
 	struct winsize ws;
+	const char *errstr = NULL;
 
 	columns = 0;
 	if (ioctl(0, TIOCGWINSZ, &ws) != -1)
 		columns = ws.ws_col;
 	if (columns == 0 && (cp = getenv("COLUMNS")))
-		columns = atoi(cp);
-	if (columns == 0)
+		columns = strtonum(cp, 0, INT_MAX, &errstr);
+	if (columns == 0 || errstr)
 		columns = 80;	/* last resort */
 	return (columns);
 }

--- a/sbin/growfs/growfs.c
+++ b/sbin/growfs/growfs.c
@@ -1229,6 +1229,7 @@ charsperline(void)
 	int columns;
 	char *cp;
 	struct winsize ws;
+	const char *errstr = NULL;
 
 	DBG_ENTER;
 
@@ -1236,8 +1237,8 @@ charsperline(void)
 	if (ioctl(0, TIOCGWINSZ, &ws) != -1)
 		columns = ws.ws_col;
 	if (columns == 0 && (cp = getenv("COLUMNS")))
-		columns = atoi(cp);
-	if (columns == 0)
+		columns = strtonum(cp, 0, INT_MAX, &errstr);
+	if (columns == 0 || errstr)
 		columns = 80;	/* last resort */
 
 	DBG_LEAVE;

--- a/sbin/ifconfig/ifconfig.c
+++ b/sbin/ifconfig/ifconfig.c
@@ -823,8 +823,11 @@ static void
 setifmetric(const char *val, int dummy __unused, int s, 
     const struct afswtch *afp)
 {
+	const char *errstr = NULL;
 	strncpy(ifr.ifr_name, name, sizeof (ifr.ifr_name));
-	ifr.ifr_metric = atoi(val);
+	ifr.ifr_metric = strtonum(val, 0, INT_MAX, &errstr);
+	if (errstr)
+		warn("invalid metric value %s", errstr);
 	if (ioctl(s, SIOCSIFMETRIC, (caddr_t)&ifr) < 0)
 		warn("ioctl (set metric)");
 }
@@ -833,8 +836,11 @@ static void
 setifmtu(const char *val, int dummy __unused, int s, 
     const struct afswtch *afp)
 {
+	const char *errstr = NULL;
 	strncpy(ifr.ifr_name, name, sizeof (ifr.ifr_name));
-	ifr.ifr_mtu = atoi(val);
+	ifr.ifr_mtu = strtonum(val, 0, INT_MAX, &errstr);
+	if (errstr)
+		warn("invalid mtu value %s", errstr);
 	if (ioctl(s, SIOCSIFMTU, (caddr_t)&ifr) < 0)
 		warn("ioctl (set mtu)");
 }

--- a/sbin/sysctl/sysctl.c
+++ b/sbin/sysctl/sysctl.c
@@ -300,7 +300,7 @@ parse(const char *string, int lineno)
  				} else {
 					intval = (int)strtol(newval, &endptr,
 					    0);
-					if (endptr == newval || *endptr != '\0') {
+					if (errno == ERANGE || endptr == newval || *endptr != '\0') {
 						warnx("invalid integer '%s'%s",
 						    (char *)newval, line);
 						return (1);
@@ -311,7 +311,7 @@ parse(const char *string, int lineno)
 				break;
 			case CTLTYPE_UINT:
 				uintval = (int) strtoul(newval, &endptr, 0);
-				if (endptr == newval || *endptr != '\0') {
+				if (errno == ERANGE || endptr == newval || *endptr != '\0') {
 					warnx("invalid unsigned integer '%s'%s",
 					    (char *)newval, line);
 					return (1);
@@ -321,7 +321,7 @@ parse(const char *string, int lineno)
 				break;
 			case CTLTYPE_LONG:
 				longval = strtol(newval, &endptr, 0);
-				if (endptr == newval || *endptr != '\0') {
+				if (errno == ERANGE || endptr == newval || *endptr != '\0') {
 					warnx("invalid long integer '%s'%s",
 					    (char *)newval, line);
 					return (1);
@@ -331,7 +331,7 @@ parse(const char *string, int lineno)
 				break;
 			case CTLTYPE_ULONG:
 				ulongval = strtoul(newval, &endptr, 0);
-				if (endptr == newval || *endptr != '\0') {
+				if (errno == ERANGE || endptr == newval || *endptr != '\0') {
 					warnx("invalid unsigned long integer"
 					    " '%s'%s", (char *)newval, line);
 					return (1);
@@ -343,7 +343,7 @@ parse(const char *string, int lineno)
 				break;
 			case CTLTYPE_S64:
 				i64val = strtoimax(newval, &endptr, 0);
-				if (endptr == newval || *endptr != '\0') {
+				if (errno == ERANGE || endptr == newval || *endptr != '\0') {
 					warnx("invalid int64_t '%s'%s",
 					    (char *)newval, line);
 					return (1);
@@ -353,7 +353,7 @@ parse(const char *string, int lineno)
 				break;
 			case CTLTYPE_U64:
 				u64val = strtoumax(newval, &endptr, 0);
-				if (endptr == newval || *endptr != '\0') {
+				if (errno == ERANGE || endptr == newval || *endptr != '\0') {
 					warnx("invalid uint64_t '%s'%s",
 					    (char *)newval, line);
 					return (1);


### PR DESCRIPTION
...999999999 => kern.maxfiles=-1, vi which can relies on env var like COLUMNS/LINES with weird values can lead to float exception and so forth ...
