### PR TITLE
Avoid undefined shift when creating 32-bit mask

### DIFF
--- a/sbin/dhclient/dhclient.c
+++ b/sbin/dhclient/dhclient.c
@@ -150,7 +150,7 @@ int
 findproto(char *cp, int n)
 {
 	struct sockaddr *sa;
-	int i;
+	unsigned int i;
 
 	if (n == 0)
 		return -1;


### PR DESCRIPTION
See the corresponding fix in OpenBSD here:

	https://github.com/openbsd/src/commit/cac6055cea954a818c7e2dc836e96910719ddaf9#diff-e342976ad51329d76ac0c3216311565d