### PR TITLE
Change OpenNTPD's user

### DIFF
--- a/contrib/openntpd/src/ntpd.h
+++ b/contrib/openntpd/src/ntpd.h
@@ -36,7 +36,7 @@
 #define MAXIMUM(a, b)	((a) > (b) ? (a) : (b))
 
 #ifndef NTPD_USER
-#define	NTPD_USER	"_ntp"
+#define	NTPD_USER	"ntpd"
 #endif
 
 #ifndef	SYSCONFDIR


### PR DESCRIPTION
It's necessary because FreeBSD introduced ntpd user under the same UID (123) as _ntp.