### PR TITLE
Correct OPENSSL_VER

### DIFF
--- a/secure/lib/libcrypto/Makefile.inc.libressl
+++ b/secure/lib/libcrypto/Makefile.inc.libressl
@@ -3,8 +3,8 @@
 .include <bsd.own.mk>
 
 # OpenSSL version used for manual page generation
-OPENSSL_VER=	2.7.3
-OPENSSL_DATE=	2018-05-05
+OPENSSL_VER=	2.7.4
+OPENSSL_DATE=	2018-06-13
 
 LIBRESSL_SRC=	${SRCTOP}/crypto/libressl
 LCRYPTO_SRC=	${LIBRESSL_SRC}/crypto


### PR DESCRIPTION
I forgot it in the original patch.