### PR TITLE
Fix vmrun.sh to work in jail

### DIFF
--- a/share/examples/bhyve/vmrun.sh
+++ b/share/examples/bhyve/vmrun.sh
@@ -106,10 +106,13 @@ if [ `id -u` -ne 0 ]; then
 	exit 1
 fi
 
-kldstat -n vmm > /dev/null 2>&1 
-if [ $? -ne 0 ]; then
-	errmsg "vmm.ko is not loaded"
-	exit 1
+JAIL_TEST=`sysctl -n security.jail.jailed`
+if [ $JAIL_TEST == 0 ]; then
+        kldstat -n vmm > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+                errmsg "vmm.ko is not loaded"
+                exit 1
+        fi
 fi
 
 force_install=0

--- a/share/examples/bhyve/vmrun.sh
+++ b/share/examples/bhyve/vmrun.sh
@@ -108,11 +108,11 @@ fi
 
 JAIL_TEST=`sysctl -n security.jail.jailed`
 if [ $JAIL_TEST == 0 ]; then
-        kldstat -n vmm > /dev/null 2>&1
-        if [ $? -ne 0 ]; then
-                errmsg "vmm.ko is not loaded"
-                exit 1
-        fi
+	kldstat -n vmm > /dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		errmsg "vmm.ko is not loaded"
+		exit 1
+	fi
 fi
 
 force_install=0


### PR DESCRIPTION
Now that there is jail support for bhyve vms, this check needs to ensure it is not running in a jail, as kldstat will not pick this up.