### PR TITLE
HBSD: Make security.bsd.unprivileged_proc_debug per-jail

### DIFF
--- a/sys/sys/pax.h
+++ b/sys/sys/pax.h
@@ -55,6 +55,7 @@ struct hbsd_features {
 	} noexec;
 	struct hbsd_hardening {
 		pax_state_t	 procfs_harden;		/* (p) Harden procfs */
+		pax_state_t	 unprivileged_proc_debug;	/* (p) Unprivileged process debugging */
 	} hardening;
 	struct hbsd_log {
 		pax_state_t	log;		/* (p) Per-jail logging status */


### PR DESCRIPTION
Teach HardenedBSD to set security.bsd.unprivileged_proc_debug per-jail.
This is needed to create jails in which the Address Sanitizer (ASAN)
fully works as ASAN utilizes libkvm to inspect the virtual address
space. Instead of having to allow unprivileged process debugging for the
entire system, allow setting it on a per-jail basis.

The sysctl node is still security.bsd.unprivileged_proc_debug, but the
jail(8) param is hardening.unprivileged_proc_debug.

There's room for a bit more improvement here. One of HardenedBSD's
internal KPI functions, pax_feature_simple_validate_state, could use a
second argument to specify the default value in case of error. That work
should be done independent of this patch.

Signed-off-by:	Shawn Webb <shawn.webb@hardenedbsd.org>
Sponsored-by:	G2, Inc
github-issue:	#360