### PR TITLE
HBSD: Make security.bsd.unprivileged_proc_debug per-jail (v2)

### DIFF
--- a/sys/hardenedbsd/hbsd_pax_hardening.c
+++ b/sys/hardenedbsd/hbsd_pax_hardening.c
@@ -133,6 +133,7 @@ pax_hardening_init_prison(struct prison *pr, struct vfsoptlist *opts)
 		/* prison0 has no parent, use globals */
 		pr->pr_hbsd.hardening.procfs_harden =
 		    pax_procfs_harden_global;
+		pr->pr_allow &= ~(PR_ALLOW_UNPRIV_DEBUG);
 	} else {
 		KASSERT(pr->pr_parent != NULL,
 		   ("%s: pr->pr_parent == NULL", __func__));

--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -196,6 +196,8 @@ static struct bool_flags pr_flag_allow[NBBY * NBPW] = {
 	{"allow.reserved_ports", "allow.noreserved_ports",
 	 PR_ALLOW_RESERVED_PORTS},
 	{"allow.read_msgbuf", "allow.noread_msgbuf", PR_ALLOW_READ_MSGBUF},
+	{"allow.unprivileged_proc_debug", "allow.nounprivileged_proc_debug",
+	 PR_ALLOW_UNPRIV_DEBUG},
 };
 const size_t pr_flag_allow_size = sizeof(pr_flag_allow);
 
@@ -504,6 +506,7 @@ kern_jail_set(struct thread *td, struct uio *optuio, int flags)
 	int ip6s, redo_ip6;
 #endif
 	uint64_t pr_allow, ch_allow, pr_flags, ch_flags;
+	uint64_t pr_allow_diff;
 	unsigned tallow;
 	char numbuf[12];
 
@@ -1544,7 +1547,9 @@ kern_jail_set(struct thread *td, struct uio *optuio, int flags)
 			}
 		}
 	}
-	if (pr_allow & ~ppr->pr_allow) {
+
+	pr_allow_diff = pr_allow & ~ppr->pr_allow;
+	if (pr_allow_diff & ~PR_ALLOW_DIFFERENCES) {
 		error = EPERM;
 		goto done_deref_locked;
 	}
@@ -3803,6 +3808,8 @@ SYSCTL_JAIL_PARAM(_allow, reserved_ports, CTLTYPE_INT | CTLFLAG_RW,
     "B", "Jail may bind sockets to reserved ports");
 SYSCTL_JAIL_PARAM(_allow, read_msgbuf, CTLTYPE_INT | CTLFLAG_RW,
     "B", "Jail may read the kernel message buffer");
+SYSCTL_JAIL_PARAM(_allow, unprivileged_proc_debug, CTLTYPE_INT | CTLFLAG_RW,
+    "B", "Unprivileged processes may use process debugging facilities");
 
 SYSCTL_JAIL_PARAM_SUBNODE(allow, mount, "Jail mount/unmount permission flags");
 SYSCTL_JAIL_PARAM(_allow_mount, , CTLTYPE_INT | CTLFLAG_RW,
@@ -3854,10 +3861,16 @@ prison_add_allow(const char *prefix, const char *name, const char *prefix_descr,
 	 * Find a free bit in prison0's pr_allow, failing if there are none
 	 * (which shouldn't happen as long as we keep track of how many
 	 * potential dynamic flags exist).
+	 *
+	 * Due to per-jail unprivileged process debugging support
+	 * using pr_allow, also verify against PR_ALLOW_ALL_STATIC.
+	 * prison0 may have unprivileged process debugging unset.
 	 */
 	for (allow_flag = 1;; allow_flag <<= 1) {
 		if (allow_flag == 0)
 			goto no_add;
+		if (allow_flag & PR_ALLOW_ALL_STATIC)
+			continue;
 		if ((prison0.pr_allow & allow_flag) == 0)
 			break;
 	}

--- a/sys/kern/kern_priv.c
+++ b/sys/kern/kern_priv.c
@@ -194,6 +194,16 @@ priv_check_cred(struct ucred *cred, int priv, int flags)
 	}
 
 	/*
+	 * Allow unprivileged process debugging on a per-jail basis.
+	 */
+	if (priv == PRIV_DEBUG_UNPRIV) {
+		if (prison_allow(cred, PR_ALLOW_UNPRIV_DEBUG)) {
+			error = 0;
+			goto out;
+		}
+	}
+
+	/*
 	 * Now check with MAC, if enabled, to see if a policy module grants
 	 * privilege.
 	 */

--- a/sys/kern/kern_prot.c
+++ b/sys/kern/kern_prot.c
@@ -1640,23 +1640,48 @@ p_cansched(struct thread *td, struct proc *p)
 }
 
 /*
+ * Handle getting or setting the prison's unprivileged_proc_debug
+ * value.
+ */
+static int
+sysctl_unprivileged_proc_debug(SYSCTL_HANDLER_ARGS)
+{
+	struct prison *pr;
+	int error, val;
+
+	val = (req->td->td_ucred->cr_prison->pr_allow &
+	    PR_ALLOW_UNPRIV_DEBUG) == PR_ALLOW_UNPRIV_DEBUG;
+	error = sysctl_handle_int(oidp, &val, 0, req);
+	if (error != 0 || req->newptr == NULL)
+		return (error);
+	pr = req->td->td_ucred->cr_prison;
+	mtx_lock(&pr->pr_mtx);
+	switch (val) {
+	case 0:
+		pr->pr_allow &= ~(PR_ALLOW_UNPRIV_DEBUG);
+		break;
+	case 1:
+		pr->pr_allow |= PR_ALLOW_UNPRIV_DEBUG;
+		break;
+	default:
+		error = EINVAL;
+	}
+	mtx_unlock(&pr->pr_mtx);
+
+	return (error);
+}
+
+/*
  * The 'unprivileged_proc_debug' flag may be used to disable a variety of
  * unprivileged inter-process debugging services, including some procfs
  * functionality, ptrace(), and ktrace().  In the past, inter-process
  * debugging has been involved in a variety of security problems, and sites
  * not requiring the service might choose to disable it when hardening
  * systems.
- *
- * XXX: Should modifying and reading this variable require locking?
- * XXX: data declarations should be together near the beginning of the file.
  */
-#ifdef PAX_HARDENING
-static int	unprivileged_proc_debug = 0;
-#else
-static int	unprivileged_proc_debug = 1;
-#endif
-SYSCTL_INT(_security_bsd, OID_AUTO, unprivileged_proc_debug, CTLFLAG_RW,
-    &unprivileged_proc_debug, 0,
+SYSCTL_PROC(_security_bsd, OID_AUTO, unprivileged_proc_debug,
+    CTLTYPE_INT | CTLFLAG_RW | CTLFLAG_PRISON, 0, 0,
+    sysctl_unprivileged_proc_debug, "I",
     "Unprivileged processes may use process debugging facilities");
 
 /*-
@@ -1674,7 +1699,7 @@ p_candebug(struct thread *td, struct proc *p)
 
 	KASSERT(td == curthread, ("%s: td not curthread", __func__));
 	PROC_LOCK_ASSERT(p, MA_OWNED);
-	if (!unprivileged_proc_debug) {
+	if (!(td->td_ucred->cr_prison->pr_allow & PR_ALLOW_UNPRIV_DEBUG)) {
 		error = priv_check(td, PRIV_DEBUG_UNPRIV);
 		if (error)
 			return (error);

--- a/sys/sys/jail.h
+++ b/sys/sys/jail.h
@@ -236,7 +236,14 @@ struct prison_racct {
 #define	PR_ALLOW_READ_MSGBUF		0x00000100
 #define	PR_ALLOW_RESERVED_PORTS		0x00008000
 #define	PR_ALLOW_KMEM_ACCESS		0x00010000	/* reserved, not used yet */
-#define	PR_ALLOW_ALL_STATIC		0x000181ff
+#define	PR_ALLOW_UNPRIV_DEBUG 		0x00020000
+#define	PR_ALLOW_ALL_STATIC		0x000381ff
+
+/*
+ * PR_ALLOW_DIFFERENCES determines which flags are able to be
+ * different between the parent and child jail upon creation.
+ */
+#define	PR_ALLOW_DIFFERENCES 		(PR_ALLOW_UNPRIV_DEBUG)
 
 /*
  * OSD methods

--- a/usr.sbin/jail/jail.8
+++ b/usr.sbin/jail/jail.8
@@ -25,7 +25,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd November 10, 2018
+.Dd November 24, 2018
 .Dt JAIL 8
 .Os
 .Sh NAME
@@ -582,6 +582,8 @@ memory subject to
 and resource limits.
 .It Va allow.reserved_ports
 The jail root may bind to ports lower than 1024.
+.It Va allow.unprivileged_proc_debug
+Unprivileged processes in the jail may use debugging facilities.
 .El
 .El
 .Pp


### PR DESCRIPTION
Teach HardenedBSD to set security.bsd.unprivileged_proc_debug per-jail.
This is needed to create jails in which the Address Sanitizer (ASAN)
fully works as ASAN utilizes libkvm to inspect the virtual address
space. Instead of having to allow unprivileged process debugging for the
entire system, allow setting it on a per-jail basis.

The sysctl node is still security.bsd.unprivileged_proc_debug and the
jail(8) param is allow.unprivileged_proc_debug. The sysctl code is now a
sysctl proc rather than a sysctl int. This allows us to determine
setting the flag for the corresponding jail (or prison0).

As part of the change, the dynamic allow.* API needed to be modified to
take into account pr_allow flags which may now be disabled in prison0.
This prevents conflicts with new pr_allow flags (like that of vmm(4))
that are added (and removed) dynamically.

Also teach the jail creation KPI to allow differences for certain
pr_allow flags between the parent and child jail. This can happen when 
unprivileged process debugging is disabled in the parent prison, but
enabled in the child.

This patch is a candidate for upstreaming to FreeBSD.

Signed-off-by:  Shawn Webb <shawn.webb@hardenedbsd.org>
Submitted-by:   G2, Inc
github-issue:   #360 
MFC-to:         12-STABLE