### PR TITLE
Remove device from HARDENEDBSD kernel config

### DIFF
--- a/sys/amd64/conf/HARDENEDBSD
+++ b/sys/amd64/conf/HARDENEDBSD
@@ -153,7 +153,6 @@ device		mps			# LSI-Logic MPT-Fusion 2
 device		mpr			# LSI-Logic MPT-Fusion 3
 #device		ncr			# NCR/Symbios Logic
 device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
-#device		trm			# Tekram DC395U/UW/F DC315U adapters
 
 device		isci			# Intel C600 SAS controller
 

--- a/sys/amd64/conf/HARDENEDBSD
+++ b/sys/amd64/conf/HARDENEDBSD
@@ -153,7 +153,7 @@ device		mps			# LSI-Logic MPT-Fusion 2
 device		mpr			# LSI-Logic MPT-Fusion 3
 #device		ncr			# NCR/Symbios Logic
 device		sym			# NCR/Symbios Logic (newer chipsets + those of `ncr')
-device		trm			# Tekram DC395U/UW/F DC315U adapters
+#device		trm			# Tekram DC395U/UW/F DC315U adapters
 
 device		isci			# Intel C600 SAS controller
 


### PR DESCRIPTION
Based on https://svnweb.freebsd.org/base?view=revision&revision=355164 the device has been removed. This is apparently only in the amd64 Kernel configs