### PR TITLE
[bsdinstall] hide random pids option & modifies the hardening options numbers

### DIFF
--- a/usr.sbin/bsdinstall/scripts/hardening
+++ b/usr.sbin/bsdinstall/scripts/hardening
@@ -76,13 +76,12 @@ FEATURES=$( dialog --backtitle "HardenedBSD Installer" \
 	"2 hide_jail" "Hide processes running in jails" ${hide_jail:-off} \
 	"3 read_msgbuf" "Disable reading kernel message buffer for unprivileged users" ${read_msgbuf:-off} \
 	"4 proc_debug" "Disable process debugging facilities for unprivileged users" ${proc_debug:-off} \
-	"5 random_pid" "Randomize the PID of newly created processes" ${random_pid:-off} \
-	"6 clear_tmp" "Clean the /tmp filesystem on system startup" ${clear_tmp:-off} \
-	"7 disable_syslogd" "Disable opening Syslogd network socket (disables remote logging)" ${disable_syslogd:-off} \
-	"8 disable_sendmail" "Disable Sendmail service" ${disable_sendmail:-off} \
-	"9 secure_console" "Enable console password prompt" ${secure_console:-off} \
-	"10 disable_ddtrace" "Disallow DTrace destructive-mode" ${disable_ddtrace:-off} \
-	"11 enable_aslr" "Enable address layout randomization" ${enable_aslr:-off} \
+	"5 clear_tmp" "Clean the /tmp filesystem on system startup" ${clear_tmp:-off} \
+	"6 disable_syslogd" "Disable opening Syslogd network socket (disables remote logging)" ${disable_syslogd:-off} \
+	"7 disable_sendmail" "Disable Sendmail service" ${disable_sendmail:-off} \
+	"8 secure_console" "Enable console password prompt" ${secure_console:-off} \
+	"9 disable_ddtrace" "Disallow DTrace destructive-mode" ${disable_ddtrace:-off} \
+	"10 enable_aslr" "Enable address layout randomization" ${enable_aslr:-off} \
 2>&1 1>&3 )
 exec 3>&-
 
@@ -102,9 +101,6 @@ for feature in $FEATURES; do
 		;;
 	proc_debug)
 		echo security.bsd.unprivileged_proc_debug=0 >> $BSDINSTALL_TMPETC/sysctl.conf.hardening
-		;;
-	random_pid)
-		echo kern.randompid=1 >> $BSDINSTALL_TMPETC/sysctl.conf.hardening
 		;;
 	clear_tmp)
 		echo 'clear_tmp_enable="YES"' >> $BSDINSTALL_TMPETC/rc.conf.hardening


### PR DESCRIPTION
Hi,

Fix issue [#34](https://git.hardenedbsd.org/hardenedbsd/HardenedBSD/-/issues/34) signaled by Jonas Rinner.

Thank you.

Best regards,

Loic